### PR TITLE
[Feat] Improve UX with same page popup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -565,3 +565,4 @@ when(groupConfigurations.loaded).then(async () => {
     }
   })
 })
+

--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,10 @@
         font-weight: 500;
         src: url('/fonts/roboto-v20-latin-500.woff2') format('woff2');
       }
+      #app {
+				width: 350px;
+				height: 450px;
+      }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Options</title>

--- a/src/index.html
+++ b/src/index.html
@@ -51,8 +51,8 @@
         src: url('/fonts/roboto-v20-latin-500.woff2') format('woff2');
       }
       #app {
-				width: 350px;
-				height: 450px;
+	width: 350px;
+	height: 450px;
       }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -14,9 +14,8 @@
   "background": {
     "service_worker": "background.js"
   },
-  "options_ui": {
-    "open_in_tab": true,
-    "page": "index.html"
+  "action": {
+	  "default_popup": "index.html"
   },
   "permissions": ["tabs", "tabGroups", "storage"]
 }

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -15,7 +15,7 @@
     "service_worker": "background.js"
   },
   "action": {
-	  "default_popup": "index.html"
+    "default_popup": "index.html"
   },
   "permissions": ["tabs", "tabGroups", "storage"]
 }

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -15,7 +15,7 @@
     "service_worker": "background.js"
   },
   "options_ui": {
-    "open_in_tab": false,
+    "open_in_tab": true,
     "page": "index.html"
   },
   "permissions": ["tabs", "tabGroups", "storage"]


### PR DESCRIPTION
Currently, the user has to click on options in the drop-down and the user is redirected to a new tab where the extensions settings is opened. This is prone to a bad user experience (UX). Therefore, to improve the user experience, make the extension icon clickable and on click, open the extension as a popup in the same page.