### PR TITLE
Ability to import and export configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 *.local
 auto-group-tabs.zip
 /extension
+.idea
+*.iml

--- a/src/background.ts
+++ b/src/background.ts
@@ -395,7 +395,7 @@ watch(
           tab => tab.groupId === groupToDelete.id
         )
 
-        chrome.tabs.ungroup(tabsToUngroup.flatMap(tab => tab.id ?? []))
+        await chrome.tabs.ungroup(tabsToUngroup.flatMap(tab => tab.id ?? []))
       }
     }
 
@@ -456,7 +456,7 @@ watch(chromeState.tabGroups.lastUpdated, async tabGroup => {
     updatedGroupItem.title = tabGroup.title ?? ''
     updatedGroupItem.color = tabGroup.color
 
-    saveGroupConfigurations(groupsCopy)
+    await saveGroupConfigurations(groupsCopy)
 
     if (conflictingItem) {
       // When there was a conflict, and the conflicting group has been renamed,

--- a/src/background.ts
+++ b/src/background.ts
@@ -569,3 +569,19 @@ when(groupConfigurations.loaded).then(async () => {
 chrome.action.onClicked.addListener(() => {
   chrome.runtime.openOptionsPage()
 })
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.data === "exportGroupConfigurations") {
+    console.debug("Exporting group configurations")
+    const result = JSON.stringify(groupConfigurations.data.value);
+    const url = 'data:application/json;base64,' + btoa(result);
+    chrome.downloads.download({
+      url,
+      filename: 'groupConfigurations.json'
+    });
+  } else {
+    console.log('Unknown message type')
+  }
+
+  return true;
+})

--- a/src/components/Dialog/ImportDialog.vue
+++ b/src/components/Dialog/ImportDialog.vue
@@ -1,0 +1,184 @@
+<template>
+  <OverlayDialog @keydown.esc="cancel" @keydown.enter="save">
+    <TabBar
+        tab-title="Import"
+        :group-title="'Configuration'"
+        class="preview"
+        :style="{
+        '--group-color': `var(--group-blue)`,
+        '--group-foreground-color': `var(--group-blue-foreground)`
+      }"
+    />
+
+    <Textfield
+      ref="inputField"
+      class="json-input"
+      v-model="jsonInput"
+      :placeholder="msg.importJsonPlaceholder"
+    />
+
+    <template v-slot:actionsBar>
+      <mwc-button
+        class="button-save"
+        dialogAction="ok"
+        unelevated
+        @click="save"
+        v-text="msg.buttonSave"
+      />
+
+      <mwc-button
+        class="button-cancel"
+        style="--mdc-theme-primary: var(--dimmed)"
+        @click="cancel"
+        v-text="msg.buttonCancel"
+      />
+    </template>
+  </OverlayDialog>
+</template>
+
+<script setup lang="ts">
+import Textfield from '@/components/Form/Textfield.vue'
+import OverlayDialog from './OverlayDialog.vue'
+import TabBar from '@/components/TabBar.vue'
+
+import { onMounted, ref } from 'vue'
+
+const emit = defineEmits<{
+  (e: 'save', inputJson: string): void
+  (e: 'cancel'): void
+  (e: 'close'): void
+}>()
+
+const inputField = ref()
+const jsonInput = ref()
+
+onMounted(() => {
+  // Need to wait for the <mwc-*> custom elements to render
+  requestAnimationFrame(() => {
+    inputField.value.focus()
+    inputField.value.select()
+  })
+})
+
+function save(event: KeyboardEvent) {
+  if (!inputField.value.isValid()) return
+
+  event.preventDefault()
+
+  emit('save', jsonInput.value)
+  emit('close')
+}
+
+function cancel() {
+  emit('cancel')
+  emit('close')
+}
+</script>
+
+<style lang="scss" scoped>
+.group-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  font-size: 14px;
+  font-weight: 400;
+  cursor: default;
+
+  &.grey {
+    --group-color: var(--group-grey);
+  }
+  &.blue {
+    --group-color: var(--group-blue);
+  }
+  &.red {
+    --group-color: var(--group-red);
+  }
+  &.yellow {
+    --group-color: var(--group-yellow);
+  }
+  &.green {
+    --group-color: var(--group-green);
+  }
+  &.pink {
+    --group-color: var(--group-pink);
+  }
+  &.purple {
+    --group-color: var(--group-purple);
+  }
+  &.cyan {
+    --group-color: var(--group-cyan);
+  }
+
+  .tag {
+    position: relative;
+    display: inline-block;
+    border-radius: 5px;
+    padding: 0.35em 0.6em;
+    margin-left: 0.5em;
+    color: var(--group-foreground);
+    background-color: var(--group-color);
+    z-index: 1;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  .divider {
+    position: absolute;
+    top: 1.65em;
+    margin: 0;
+    padding: 0;
+    border: none;
+    width: 100%;
+    height: 4px;
+    border-radius: 1px;
+    background-color: var(--group-color);
+  }
+
+  .edit {
+    margin-left: auto;
+    margin-right: 0.25em;
+    z-index: 1;
+    color: var(--foreground);
+    background: var(--background);
+  }
+
+  .eyedropper {
+    color: var(--foreground);
+    background: var(--background);
+    z-index: 1;
+    padding-left: 0.25em;
+    margin-right: -1px;
+  }
+
+  .color-button {
+    --mdc-theme-primary: var(--group-color);
+  }
+}
+
+mwc-dialog {
+  @media (prefers-color-scheme: dark) {
+    --mdc-dialog-box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 1),
+      0px 24px 38px 3px rgba(0, 0, 0, 1), 0px 9px 46px 8px rgba(0, 0, 0, 1);
+  }
+}
+
+.group-title {
+  margin: 1.5rem 0;
+}
+
+.preview {
+  width: 100vw;
+  box-sizing: border-box;
+  margin: 0 calc(-1 * var(--body-padding)) var(--body-padding);
+  padding: 8px var(--body-padding) 0 !important;
+}
+
+.button-cancel {
+  margin-left: auto;
+  order: -1;
+}
+</style>

--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,10 @@
         font-weight: 500;
         src: url('/fonts/roboto-v20-latin-500.woff2') format('woff2');
       }
+
+      #app {
+		      min-width: 400px;
+      }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Options</title>

--- a/src/static/_locales/en/messages.json
+++ b/src/static/_locales/en/messages.json
@@ -51,6 +51,14 @@
     "message": "Enable sort mode",
     "description": "Sort mode"
   },
+  "buttonExportConfig": {
+    "message": "Export Configuration",
+    "description": "Label for export configuration button"
+  },
+  "buttonImportConfig": {
+    "message": "Import Configuration",
+    "description": "Label for import configuration button"
+  },
   "buttonAddGroup": {
     "message": "Add group",
     "description": "Add group button label"
@@ -58,6 +66,10 @@
   "groupTitlePlaceholder": {
     "message": "Group title",
     "description": "Placeholder of a group title input"
+  },
+  "importJsonPlaceholder": {
+    "message": "Enter configuration in JSON format",
+    "description": "Placeholder of the import text field"
   },
   "urlInputPlaceholder": {
     "message": "URL pattern",

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -18,6 +18,9 @@
     "open_in_tab": false,
     "page": "index.html"
   },
-  "action": {},
+  "action": {
+    "default_action": "Manage Tab Auto Grouping",
+    "default_popup": "index.html"
+  },
   "permissions": ["tabs", "tabGroups", "storage"]
 }

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -22,5 +22,5 @@
     "default_action": "Manage Tab Auto Grouping",
     "default_popup": "index.html"
   },
-  "permissions": ["tabs", "tabGroups", "storage"]
+  "permissions": ["tabs", "tabGroups", "storage", "downloads"]
 }

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -18,9 +18,6 @@
     "open_in_tab": false,
     "page": "index.html"
   },
-  "action": {
-    "default_action": "Manage Tab Auto Grouping",
-    "default_popup": "index.html"
-  },
+  "action": {},
   "permissions": ["tabs", "tabGroups", "storage", "downloads"]
 }


### PR DESCRIPTION
This PR allows users to export their configuration as a JSON file and then import it again. This is useful for sharing config amongst team members, between computers, or just backing up their config.

The user has to manually enter the JSON when importing config, this isn't ideal but I couldn't find a way of opening a file from within an extension.

If a duplicate ID is detected, the config being imported takes precedence (e.g. title or colour changes). Matches are merged.