### PR TITLE
fix: use fileURLToPath for Windows-compatible __dirname and extract m…

### DIFF
--- a/build-manifest.ts
+++ b/build-manifest.ts
@@ -1,0 +1,5 @@
+import fs from 'node:fs'
+
+const target = process.argv[2]
+const manifest = (await import(`./src/manifest/manifest.${target}.ts`)).default
+fs.writeFileSync(`extension-${target}/manifest.json`, JSON.stringify(manifest, null, 2))

--- a/pack.ts
+++ b/pack.ts
@@ -1,11 +1,12 @@
 import { createWriteStream } from 'node:fs'
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import archiver from 'archiver'
 
 const target = process.argv[2]
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 const output = createWriteStream(
   resolve(__dirname, `auto-group-tabs.${target}.zip`),
 )

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       ]
     },
     "build:manifest:chromium": {
-      "command": "node -e 'fs.writeFileSync(\"extension-chromium/manifest.json\", JSON.stringify((await import(\"./src/manifest/manifest.chromium.ts\")).default, null, 2))'",
+      "command": "node build-manifest.ts chromium",
       "files": [
         "src/**/*",
         "!src/node_modules"
@@ -112,7 +112,7 @@
       ]
     },
     "build:manifest:gecko": {
-      "command": "node -e 'fs.writeFileSync(\"extension-gecko/manifest.json\", JSON.stringify((await import(\"./src/manifest/manifest.gecko.ts\")).default, null, 2))'",
+      "command": "node build-manifest.ts gecko",
       "files": [
         "src/**/*",
         "!src/node_modules"

--- a/rolldown-background.chromium.config.ts
+++ b/rolldown-background.chromium.config.ts
@@ -1,8 +1,9 @@
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { defineConfig } from 'rolldown'
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
   resolve: {

--- a/rolldown-background.gecko.config.ts
+++ b/rolldown-background.gecko.config.ts
@@ -1,8 +1,9 @@
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { defineConfig } from 'rolldown'
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
   resolve: {

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -1,13 +1,14 @@
 // Configuration for bundling the options page
 
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import vue from '@vitejs/plugin-vue'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import vuetify from 'vite-plugin-vuetify'
 import { defineConfig } from 'vitest/config'
 
-const __dirname = new URL('.', import.meta.url).pathname
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // See https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
##  Summary

  - Replaces `new URL('.', import.meta.url).pathname` with `fileURLToPath(new URL('.', import.meta.url))` across pack.ts, vite.base.config.ts, and both rolldown background configs  on Windows the
  .pathname approach returns /D:/... with a leading slash that breaks resolve()
  - Extracts the inline `node -e manifest` build commands from `package.json` into a standalone `build-manifest.ts` script to avoid shell quoting issues on Windows

Should resolve #82