### PR TITLE
fix: read previous history snapshot when syncing manual tab group edits

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -526,7 +526,10 @@ watch(chromeState.tabGroups.lastUpdated, async tabGroup => {
   if (!tabGroup) return
   if (programmaticallyUpdatingTabGroups.value) return
 
-  const oldTabGroup = tabGroupsHistory.history.value[0].snapshot.find(
+  const previousSnapshot = tabGroupsHistory.history.value[1]?.snapshot
+  if (!previousSnapshot) return
+
+  const oldTabGroup = previousSnapshot.find(
     stateTabGroup => stateTabGroup.id === tabGroup!.id,
   )
   if (!oldTabGroup) return


### PR DESCRIPTION
## Summary

  - useRefHistory stores the most recent entry at index [0], so the old code was always comparing the updated state to itself — the equality check always passed, silently preventing manual
  renames/recolors from ever syncing back to the extension configuration
  - This also fixes the downstream issue where changing a group's color from the Options page had no effect on existing Chrome tab groups, because the configuration and Chrome's actual tab group state had drifted out of sync

May resolve #84 